### PR TITLE
Add a set module

### DIFF
--- a/can-key-test.js
+++ b/can-key-test.js
@@ -1,4 +1,5 @@
 require("./get/get-test");
+require("./set/set-test");
 require("./sub/sub-test");
 require("./replace-with/replace-with-test");
 require("./transform/transform-test");

--- a/can-key.js
+++ b/can-key.js
@@ -1,6 +1,7 @@
 var deleteKey = require("can-key/delete/delete"),
     get = require("can-key/get/get"),
     replaceWith = require("can-key/replace-with/replace-with"),
+    set = require("can-key/set/set"),
     transform = require("can-key/transform/transform"),
     walk = require("can-key/walk/walk");
 
@@ -8,6 +9,7 @@ module.exports = {
     deleteKey: deleteKey,
     get: get,
     replaceWith: replaceWith,
+    set: set,
     transform: transform,
     walk: walk
 };

--- a/get/get.js
+++ b/get/get.js
@@ -5,11 +5,14 @@ var utils = require("../utils");
 /**
  * @module {function} can-key/get/get
  * @parent can-key
+ * @description Get properties on deep/nested objects of different types: Object, Map, [can-reflect] types, etc.
  *
  * @signature `get(obj, path)`
- * @param  {Object} obj the object to use as the root for property based navigation
+ * @param  {Object} obj the object to use as the root for property-based navigation
  * @param  {String} path a String of dot-separated keys, representing a path of properties
  * @return {*}       the value at the property path
+ *
+ * @body
  *
  * A *path* is a dot-delimited sequence of zero or more property names, such that "foo.bar" means "the property
  * 'bar' of the object at the property 'foo' of the root."  An empty path returns the object passed.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     ]
   },
   "dependencies": {
-    "can-reflect": "^1.13.3"
+    "can-reflect": "^1.13.3",
+    "can-symbol": "^1.0.0"
   },
   "devDependencies": {
     "jshint": "^2.9.1",

--- a/replace-with/replace-with.js
+++ b/replace-with/replace-with.js
@@ -30,6 +30,7 @@ var deleteKey = require("../delete/delete");
  * found in delimiters in `str` from `data`.
  * @return {String} the supplied string with delimited properties replaced with their values.
  *
+ * @body
  *
  * ```js
  * var replaceWith = require("can-key/replace-with/replace-with");

--- a/set/set-test.js
+++ b/set/set-test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+var QUnit = require("steal-qunit");
+
+var set  = require("./set");
+var canReflect = require("can-reflect");
+
+QUnit.module("can-key/set");
+
+QUnit.test("set single root", function (assert) {
+	var root = {
+		foo: "bar"
+	};
+	set(root, "foo", "baz");
+	assert.equal(root.foo, "baz", "got 'baz'");
+});
+
+QUnit.test("set deep objects", function (assert) {
+	var root = {
+		foo: {
+			bar: "baz"
+		}
+	};
+	set(root, "foo.bar", "new");
+	assert.equal(root.foo.bar, "new", "got 'new'");
+});
+
+QUnit.test("set with numeric index", function (assert) {
+	var list = [1, 2, 3];
+	set(list, 0, "one");
+
+	assert.equal(list[0], "one", "set the 1st element of the list");
+
+	set(list, 1, "two");
+	assert.equal(list[1], "two", "set the 2nd element of the list");
+});
+
+QUnit.test("set on an object that does not exist", function (assert) {
+	var root = {
+		foo: {}
+	};
+	var errorThrown;
+	try {
+		set(root, "foo.bar.baz", "new");
+	} catch (error) {
+		errorThrown = error;
+	}
+	assert.ok(errorThrown instanceof TypeError, "error was thrown");
+	assert.equal(root.foo.bar, undefined, "original object was not modified");
+});
+
+QUnit.test("works with reflected APIs", function(assert) {
+    var obj = canReflect.assignSymbols({}, {
+        "can.getKeyValue": function(key) {
+            return this._data[key];
+        },
+        "can.setKeyValue": function(key, value) {
+            this._data[key] = value;
+        }
+    });
+    obj._data = {foo: {
+        bar: "zed"
+    }};
+
+    set(obj, "foo.bar", "baz");
+    assert.equal(obj._data.foo.bar, "baz", "got 'baz'");
+});
+
+if (typeof Map !== undefined) {
+    QUnit.test("works with Map", function(assert) {
+        var map = new Map();
+        map.set("first", {second: "third"});
+        set(map, "first.second", "3rd");
+        assert.equal(map.get("first").second, "3rd");
+    });
+}

--- a/set/set.js
+++ b/set/set.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var canReflect = require("can-reflect");
+var canSymbol = require("can-symbol");
+var utils = require("../utils");
+
+var setValueSymbol = canSymbol.for("can.setValue");
+
+/**
+ * @module {function} can-key/set/set
+ * @parent can-key
+ * @description Set properties on deep/nested objects of different types: Object, Map, [can-reflect] types, etc.
+ *
+ * @signature `set(object, path, value)`
+ * @param  {Object} object The object to use as the root for property-based navigation.
+ * @param  {String} path A String of dot-separated keys, representing a path of properties.
+ * @param  {*} value The new value to be set at the property path.
+ * @return {*} The object passed to set (for chaining calls).
+ *
+ * @body
+ *
+ * A *path* is a dot-delimited sequence of one or more property names, such that "foo.bar" means "the property
+ * 'bar' of the object at the property 'foo' of the root."
+ *
+ * ```js
+ * import set from "can-key/set/set";
+ *
+ * const object = {a: {b: {c: "foo"}}};
+ * set(object, "a.b.c", "bar");
+ * // Now object.a.b.c === "bar"
+ *
+ * var map = new Map();
+ * map.set("first", {second: "third"});
+ *
+ * set(map, "first.second", "3rd");
+ * // Now map.first.second === "3rd"
+ * ```
+ *
+ * > **Note:** an error will be thrown if one of the objects in the key path does not exist.
+ */
+function set(object, path, value) {
+    var parts = utils.parts(path);
+
+    var current = object;
+    var length = parts.length;
+
+    // Walk current until there is not a container
+    for (var i = 0; i < length - 1; i++) {
+        if (utils.isContainer(current)) {
+            current = canReflect.getKeyValue(current, parts[i]);
+        } else {
+            break;
+        }
+    }
+
+    // Set the value
+    if (current) {
+        canReflect.setKeyValue(current, parts[i], value);
+    } else {
+        throw new TypeError("Cannot set value at key path '" + path + "'");
+    }
+
+    return object;
+}
+
+module.exports = set;


### PR DESCRIPTION
`set(object, path, value)` makes it possible to set properties on deep/nested objects of different types: Object, Map, can-reflect types, etc.

This also fixes a couple minor issues with some of the other docs.

<img width="664" alt="screen shot 2018-04-05 at 4 40 54 pm" src="https://user-images.githubusercontent.com/10070176/38397019-2afd1e74-38f0-11e8-9781-26991d011793.png">
